### PR TITLE
Deploy Pyth to testnet networks

### DIFF
--- a/ethereum/.openzeppelin/goerli.json
+++ b/ethereum/.openzeppelin/goerli.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0x04cfb919fca33bf75dc7626a1ede69fde0a409e9eb26f1e6dac1b7702f92d567",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0xe5a8cf3e4ae5b74b739cbb87b03bdf915e2ff67f98b6adb323a92a7dbdab525c",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/ropsten.json
+++ b/ethereum/.openzeppelin/ropsten.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0x78f8960b670a27f63a846ff99f25dc64f7c2fc8b843c7f166abe64f24a5cb87e",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0xb28e10ce65a0dd4011c6011e795d5bf7ebab4c0179d35502775b367c9adcfd00",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/unknown-1337.json
+++ b/ethereum/.openzeppelin/unknown-1337.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0x787bc8317c315b450af392e9ce1d1b4fd0c8e6a64a2340f4e460267f57bb0245",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0x060e021b6459b82ea6a533d3af5a61fe2ecf840eb5f0ace9553fb57ea3d1682a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/unknown-4002.json
+++ b/ethereum/.openzeppelin/unknown-4002.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0x0261874d2b5cd39e4a6b49276d13089d80e0a5a43efa82fc9cab9986633bd67e",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0xbe9ab193ec6af23ccf232dce4c16079e550d440a655ec3102266e92285e5e997",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/unknown-43113.json
+++ b/ethereum/.openzeppelin/unknown-43113.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0xf9f70f6671e8a5cbfcc04a93344260674aeb129cf6b3d7278f8c4712aea04f77",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0xdabcfb5f7e2c0969827459fa075256ec35326d388c37448fdd4c374ea5e56fa0",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/unknown-80001.json
+++ b/ethereum/.openzeppelin/unknown-80001.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+      "txHash": "0xad07603dc3bdf109bdffb95097303b5cb6c254e9cd13538d8f73edcebc525ebf",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xB2eeb93D778c364E7E2274D6299e2aa0c2Bea090",
+      "txHash": "0x94cb06fd66529fd67bdeaabf94f7ae70c2b022efb434ca7fde0d15b7add6574f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/.openzeppelin/unknown-97.json
+++ b/ethereum/.openzeppelin/unknown-97.json
@@ -1,0 +1,221 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xd7308b14BF4008e7C7196eC35610B1427C5702EA",
+      "txHash": "0xaf87d230967901c4122ae191647efb5016033d2b4130e3d174ea136633f2fb8f",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "5c31ffd0774368a91446d42c3ea317dd996266a4587c3c67efd448d66ae5e5c9": {
+      "address": "0xc1dF98e0656558059bE61a5aF5Ad91Bd7B63DFA4",
+      "txHash": "0x4c1826e62d0030d460da8252be87b39d60dcadd7a261da4f5f5a54493843122b",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "contract": "ERC1967UpgradeUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "contract": "UUPSUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "../@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "contract": "PythState",
+            "label": "_state",
+            "type": "t_struct(State)3714_storage",
+            "src": "../project:/contracts/pyth/PythState.sol:21"
+          }
+        ],
+        "types": {
+          "t_struct(State)3714_storage": {
+            "label": "struct PythStorage.State",
+            "members": [
+              {
+                "label": "wormhole",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "pyth2WormholeChainId",
+                "type": "t_uint16"
+              },
+              {
+                "label": "pyth2WormholeEmitter",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "latestPriceInfo",
+                "type": "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_uint16": {
+            "label": "uint16"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_struct(PriceInfo)3636_storage)": {
+            "label": "mapping(bytes32 => struct PythInternalStructs.PriceInfo)"
+          },
+          "t_struct(PriceInfo)3636_storage": {
+            "label": "struct PythInternalStructs.PriceInfo",
+            "members": [
+              {
+                "label": "attestationTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalTime",
+                "type": "t_uint256"
+              },
+              {
+                "label": "arrivalBlock",
+                "type": "t_uint256"
+              },
+              {
+                "label": "priceFeed",
+                "type": "t_struct(PriceFeed)2228_storage"
+              }
+            ]
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(PriceFeed)2228_storage": {
+            "label": "struct PythStructs.PriceFeed",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "productId",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "price",
+                "type": "t_int64"
+              },
+              {
+                "label": "conf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "expo",
+                "type": "t_int32"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(PriceStatus)2233"
+              },
+              {
+                "label": "maxNumPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "numPublishers",
+                "type": "t_uint32"
+              },
+              {
+                "label": "emaPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "emaConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "publishTime",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPrice",
+                "type": "t_int64"
+              },
+              {
+                "label": "prevConf",
+                "type": "t_uint64"
+              },
+              {
+                "label": "prevPublishTime",
+                "type": "t_uint64"
+              }
+            ]
+          },
+          "t_int64": {
+            "label": "int64"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_int32": {
+            "label": "int32"
+          },
+          "t_enum(PriceStatus)2233": {
+            "label": "enum PythStructs.PriceStatus",
+            "members": [
+              "UNKNOWN",
+              "TRADING",
+              "HALTED",
+              "AUCTION"
+            ]
+          },
+          "t_uint32": {
+            "label": "uint32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/ethereum/Deploying.md
+++ b/ethereum/Deploying.md
@@ -76,3 +76,11 @@ $ npx truffle console --network $MIGRATIONS_NETWORK
 ```
 
 [pyth-js]: https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js#evmrelay
+
+# Manually Verifying the contract
+
+Run the following command:
+
+`npx sol-merger contracts/pyth/PythUpgradable.sol`
+
+It will create a new file `PythUpgradable_merged.sol` which you can use in etherscan to verify the implementation contract (using exact sol version and optimization flag). After verifying implementation, you can verify the proxy.

--- a/ethereum/Deploying.md
+++ b/ethereum/Deploying.md
@@ -63,3 +63,14 @@ module.exports = async function (deployer) {
     await upgradeProxy(instance.address, PythUpgradable, { deployer });
 }
 ```
+
+# Testing
+Using (pyth-evm-js)[https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js] relay example you can do a relaying and it should be successful. 
+
+Then to check the price feeds you can do
+
+```
+$ npx truffle console --network $MIGRATIONS_NETWORK
+> let p = await PythUpgradable.deployed()
+> p.queryPriceFeed("0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b") // BTC Testnet or any other address
+```

--- a/ethereum/Deploying.md
+++ b/ethereum/Deploying.md
@@ -65,12 +65,14 @@ module.exports = async function (deployer) {
 ```
 
 # Testing
-Using (pyth-evm-js)[https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js] relay example you can do a relaying and it should be successful. 
 
-Then to check the price feeds you can do
+The [pyth-js][] repository contains an example with documentation and a code sample showing how to relay your own prices to a
+target Pyth network. Once you have relayed a price, you can verify the price feed has been updated by doing:
 
 ```
 $ npx truffle console --network $MIGRATIONS_NETWORK
 > let p = await PythUpgradable.deployed()
 > p.queryPriceFeed("0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b") // BTC Testnet or any other address
 ```
+
+[pyth-js]: https://github.com/pyth-network/pyth-js/tree/main/pyth-evm-js#evmrelay

--- a/ethereum/networks/3.json
+++ b/ethereum/networks/3.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x1c6Cd107fB71768FBc46F8B6180Eec155C03eEb5"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "transactionHash": "0x78f8960b670a27f63a846ff99f25dc64f7c2fc8b843c7f166abe64f24a5cb87e"
+  }
+]

--- a/ethereum/networks/4002.json
+++ b/ethereum/networks/4002.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x1c6Cd107fB71768FBc46F8B6180Eec155C03eEb5"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "transactionHash": "0x0261874d2b5cd39e4a6b49276d13089d80e0a5a43efa82fc9cab9986633bd67e"
+  }
+]

--- a/ethereum/networks/43113.json
+++ b/ethereum/networks/43113.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x1c6Cd107fB71768FBc46F8B6180Eec155C03eEb5"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "transactionHash": "0xf9f70f6671e8a5cbfcc04a93344260674aeb129cf6b3d7278f8c4712aea04f77"
+  }
+]

--- a/ethereum/networks/5.json
+++ b/ethereum/networks/5.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x1c6Cd107fB71768FBc46F8B6180Eec155C03eEb5"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "transactionHash": "0x04cfb919fca33bf75dc7626a1ede69fde0a409e9eb26f1e6dac1b7702f92d567"
+  }
+]

--- a/ethereum/networks/80001.json
+++ b/ethereum/networks/80001.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x1c6Cd107fB71768FBc46F8B6180Eec155C03eEb5"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C",
+    "transactionHash": "0xad07603dc3bdf109bdffb95097303b5cb6c254e9cd13538d8f73edcebc525ebf"
+  }
+]

--- a/ethereum/networks/97.json
+++ b/ethereum/networks/97.json
@@ -1,0 +1,11 @@
+[
+  {
+    "contractName": "Migrations",
+    "address": "0x8005731FD1b5b5751a08801FB19B75108C175c87"
+  },
+  {
+    "contractName": "PythUpgradable",
+    "address": "0xd7308b14BF4008e7C7196eC35610B1427C5702EA",
+    "transactionHash": "0xaf87d230967901c4122ae191647efb5016033d2b4130e3d174ea136633f2fb8f"
+  }
+]

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -22,7 +22,6 @@
     "build": "truffle compile",
     "test": "truffle test",
     "migrate": "mkdir -p build/contracts && cp node_modules/@openzeppelin/contracts/build/contracts/* build/contracts/ && truffle migrate",
-    "flatten": "mkdir -p node_modules/@poanet/solidity-flattener/contracts && cp -r contracts/* node_modules/@poanet/solidity-flattener/contracts/ && poa-solidity-flattener",
     "receiver-submit-guardian-sets": "truffle exec scripts/receiverSubmitGuardianSetUpgrades.js",
     "verify": "patch -u -f node_modules/truffle-plugin-verify/constants.js -i truffle-verify-constants.patch; truffle run verify $npm_config_module@$npm_config_contract_address --network $npm_config_network"
   },

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -94,7 +94,7 @@ module.exports = {
       provider: () => {
         return new HDWalletProvider(
           process.env.MNEMONIC,
-          "https://polygon-mumbai.infura.io/v3/" + process.env.INFURA_KEY)
+          "https://matic-mumbai.chainstacklabs.com")
       },
       network_id: "80001",
     },


### PR DESCRIPTION
Deploys to:
- Goerli and Ropsten (eth testnet)
- Fuji (Avalanche testnet)
- Fantom Testnet
- Mumbai (Polygon testnet)
- BNB Testnet

Also I did one successful relay in each of them and checked their values.
