### PR TITLE
ethereum: Add setContractConfig for on-chain state

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -220,7 +220,7 @@ if pyth:
     k8s_yaml_with_ns("devnet/p2w-terra-relay.yaml")
     k8s_resource(
         "p2w-terra-relay",
-        resource_deps = ["pyth", "p2w-attest", "spy", "terra-terrad"],
+        resource_deps = ["pyth", "p2w-attest", "spy", "terra-terrad", "wasm-gen"],
         port_forwards = [
             port_forward(4200, name = "Rest API (Status + Query) [:4200]", host = webHost),
             port_forward(8081, name = "Prometheus [:8081]", host = webHost)],
@@ -230,7 +230,7 @@ if pyth:
     k8s_yaml_with_ns("devnet/p2w-evm-relay.yaml")
     k8s_resource(
         "p2w-evm-relay",
-        resource_deps = ["pyth", "p2w-attest", "spy", "eth-devnet"],
+        resource_deps = ["pyth", "p2w-attest", "spy", "eth-devnet", "wasm-gen"],
         port_forwards = [
             port_forward(4201, container_port = 4200, name = "Rest API (Status + Query) [:4201]", host = webHost),
             port_forward(8082, container_port = 8081, name = "Prometheus [:8082]", host = webHost)],
@@ -246,7 +246,7 @@ if pyth:
     k8s_yaml_with_ns("devnet/pyth-price-service.yaml")
     k8s_resource(
         "pyth-price-service",
-        resource_deps = ["pyth", "p2w-attest", "spy", "eth-devnet"],
+        resource_deps = ["pyth", "p2w-attest", "spy", "eth-devnet", "wasm-gen"],
         port_forwards = [
             port_forward(4202, container_port = 4200, name = "Rest API (Status + Query) [:4202]", host = webHost),
             port_forward(8083, container_port = 8081, name = "Prometheus [:8083]", host = webHost)],

--- a/ethereum/contracts/pyth/Pyth.sol
+++ b/ethereum/contracts/pyth/Pyth.sol
@@ -28,7 +28,9 @@ contract Pyth is PythGetters, PythSetters, AbstractPyth {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
-        require(verifyPythVM(vm), "invalid emitter");
+
+	(bool pythValid, string memory pythReason) = verifyPythVM(vm);
+	require(pythValid, pythReason);
 
         PythInternalStructs.BatchPriceAttestation memory batch = parseBatchPriceAttestation(vm.payload);
 
@@ -73,14 +75,14 @@ contract Pyth is PythGetters, PythSetters, AbstractPyth {
         return info;
     }
 
-    function verifyPythVM(IWormhole.VM memory vm) private view returns (bool valid) {
+    function verifyPythVM(IWormhole.VM memory vm) private view returns (bool valid, string memory reason) {
         if (vm.emitterChainId != pyth2WormholeChainId()) {
-            return false;
+            return (false, "Invalid Chain ID");
         }
         if (vm.emitterAddress != pyth2WormholeEmitter()) {
-            return false;
+            return (false, "Invalid Emitter");
         }
-        return true;
+        return (true, "");
     }
 
 

--- a/ethereum/contracts/pyth/PythUpgradable.sol
+++ b/ethereum/contracts/pyth/PythUpgradable.sol
@@ -28,4 +28,10 @@ contract PythUpgradable is Initializable, OwnableUpgradeable, UUPSUpgradeable, P
     // Only allow the owner to upgrade the proxy to a new implementation.
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
+    /// Alter the on-chain state of the contract (does not touch actual price feed data)
+    function setContractConfig(uint16 p2wChainId, bytes32 p2wWormholeEmitterAddr, address wormhole) public onlyOwner {
+        setPyth2WormholeChainId(p2wChainId);
+        setPyth2WormholeEmitter(p2wWormholeEmitterAddr);
+        setWormhole(wormhole);
+    }
 }


### PR DESCRIPTION
This method lets us alter the emitter/wormhole/chain IDs on-chain using the owner