### PR TITLE
Price Service Multisource: Use attestationTime instead of seqnum

### DIFF
--- a/third_party/pyth/price-service/src/__tests__/rest.test.ts
+++ b/third_party/pyth/price-service/src/__tests__/rest.test.ts
@@ -40,7 +40,7 @@ function dummyPriceInfoPair(
     id,
     {
       priceFeed: dummyPriceFeed(id),
-      receiveTime: 0,
+      attestationTime: 0,
       seqNum,
       vaaBytes: Buffer.from(vaa, "hex").toString("binary"),
     },

--- a/third_party/pyth/price-service/src/listen.ts
+++ b/third_party/pyth/price-service/src/listen.ts
@@ -29,7 +29,7 @@ import { HexString, PriceFeed } from "@pythnetwork/pyth-sdk-js";
 export type PriceInfo = {
   vaaBytes: string;
   seqNum: number;
-  receiveTime: TimestampInSec;
+  attestationTime: TimestampInSec;
   priceFeed: PriceFeed;
 };
 
@@ -168,8 +168,8 @@ export class Listener implements PriceStore {
     let isAnyPriceNew = batchAttestation.priceAttestations.some(
       (priceAttestation) => {
         const key = priceAttestation.priceId;
-        let lastSeqNum = this.priceFeedVaaMap.get(key)?.seqNum;
-        return lastSeqNum === undefined || lastSeqNum < parsedVAA.sequence;
+        let lastAttestationTime = this.priceFeedVaaMap.get(key)?.attestationTime;
+        return lastAttestationTime === undefined || lastAttestationTime < priceAttestation.attestationTime;
       }
     );
 
@@ -180,13 +180,14 @@ export class Listener implements PriceStore {
     for (let priceAttestation of batchAttestation.priceAttestations) {
       const key = priceAttestation.priceId;
 
-      let lastSeqNum = this.priceFeedVaaMap.get(key)?.seqNum;
-      if (lastSeqNum === undefined || lastSeqNum < parsedVAA.sequence) {
+      let lastAttestationTime = this.priceFeedVaaMap.get(key)?.attestationTime;
+
+      if (lastAttestationTime === undefined || lastAttestationTime < priceAttestation.attestationTime) {
         const priceFeed = priceAttestationToPriceFeed(priceAttestation);
         this.priceFeedVaaMap.set(key, {
           seqNum: parsedVAA.sequence,
           vaaBytes: vaaBytes,
-          receiveTime: new Date().getTime() / 1000,
+          attestationTime: priceAttestation.attestationTime,
           priceFeed,
         });
 

--- a/third_party/pyth/price-service/src/rest.ts
+++ b/third_party/pyth/price-service/src/rest.ts
@@ -104,7 +104,7 @@ export class RestAPI {
           }
 
           const freshness: DurationInSec =
-            new Date().getTime() / 1000 - latestPriceInfo.receiveTime;
+            new Date().getTime() / 1000 - latestPriceInfo.attestationTime;
           this.promClient?.addApiRequestsPriceFreshness(
             req.path,
             id,
@@ -159,7 +159,7 @@ export class RestAPI {
           }
 
           const freshness: DurationInSec =
-            new Date().getTime() / 1000 - latestPriceInfo.receiveTime;
+            new Date().getTime() / 1000 - latestPriceInfo.attestationTime;
           this.promClient?.addApiRequestsPriceFreshness(
             req.path,
             id,


### PR DESCRIPTION
SeqNum is not suitable for multiple sources, attestationTime is good
but we should be careful of solana clock falling behind

Also use this time for freshness metric because it's more useful.